### PR TITLE
Fixed shard example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add this to your application's `shard.yml`:
 
 ```yaml
 dependencies:
-  smtp.cr:
+  smtp:
     github: raydf/smtp.cr
 ```
 


### PR DESCRIPTION
I think that the shard/dependency name shouldn't include the `.cr` suffix
