### PR TITLE
change cc and bcc to populate correctly

### DIFF
--- a/src/smtp.cr
+++ b/src/smtp.cr
@@ -147,13 +147,13 @@ module SMTP
         end
       end
 
-      if cc = @to
+      if cc = @cc
         cc.each do |rcpt|
           io << "CC: #{rcpt.to_s}\r\n"
         end
       end
 
-      if bcc = @to
+      if bcc = @bcc
         bcc.each do |rcpt|
           io << "BCC: #{rcpt.to_s}\r\n"
         end


### PR DESCRIPTION
The cc and bcc were being populated using the `to` array.  This fixes them so they correctly populate from the `cc` and `bcc` arrays.